### PR TITLE
Stream core RW methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ dkms.conf
 
 # compiled
 bin/
+
+# testing
+sandbox/*.c
+sandbox/sandbox

--- a/include/FireStream.h
+++ b/include/FireStream.h
@@ -1,8 +1,10 @@
 #ifndef FIRE_STREAM_H
 #define FIRE_STREAM_H
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "FireTypes.h"
 #include "FireMap.h"
@@ -18,172 +20,20 @@
 //meant to fit 100 8-bit integers by default
 #define FireStream_DEFAULT_SIZE 800
 
-
-
-
-
-
-// calculates the length of stream
+// macro calculates the length of stream
 #define FireStream_LEN(stream) (stream->itemEnd - stream->items)
 
-// calculates remaining space in stream
+// macro calculates remaining space in stream
 #define FireStream_SPACE(stream) (stream->end - stream->itemEnd)
 
 
-#define FireStream_MAKE(stream, size) do { \
-                stream->items = malloc(size); \
-                stream->cap = size; \
-                stream->end = stream->items + stream->cap; \
-                stream->itemEnd = stream->items; \
-} while(0)
-
-// make macro for literal and not ptr stream
-#define FireStream_MAKE_L(stream, size) do { \
-                stream.items = malloc(size); \
-                stream.cap = size; \
-                stream.end = stream.items + stream.cap; \
-                stream.itemEnd = stream.items; \
-} while(0)
-
-// macro that takes a void* data, and some n bytes to make into a new stream
-// onto the FireStream* stream.
-#define FireStream_MAKE_FROM(stream, data, n) do { \
-                stream->items = malloc(n); \
-                memcpy(stream->items, data, n); \
-                stream->cap = n; \
-                stream->end = stream->items + stream->cap; \
-                stream->itemEnd = stream->items; \
-} while(0)
-
-// like other MAKE macros, this initializes a zero range stream
-#define FireStream_MAKE_ZRNG(stream, endMark) do { \
-                stream->cap = endMark * (sizeof(double) + 1) + 100; \
-                stream->items = malloc(stream->cap); \
-                stream->end = stream->items + stream->cap; \
-                stream->itemEnd = stream->items; \
-                for (double i = 0; i < endMark; i++) { \
-                        FireStream_PUT_LNUM(stream, i); \
-                } \
-} while(0)
-
-// like other MAKE macros, this initializes a stream of all the same numbers
-#define FireStream_MAKE_SNUM(stream, endMark) do { \
-                stream->cap = endMark * (sizeof(double) + 1) + 100; \
-                stream->items = malloc(stream->cap); \
-                stream->end = stream->items + stream->cap; \
-                stream->itemEnd = stream->items; \
-                for (double i = 0; i < endMark; i++) { \
-                        FireStream_PUT_LNUM(stream, endMark); \
-                } \
-} while(0)
-
-// pushes a range of numbers to the stream.
-// end is a pointer to a number
-#define FireStream_PUSH_ZRNG(stream, end) do { \
-                for (double i = 0; i < *(double*)end; i++) FireStream_PUSH_LNUM(stream, i); \
-} while(0)
-
-// macro for expanding stream
-#define FireStream_EXPAND(stream, newSize) do { \
-                size_t ilen = stream->itemEnd - stream->items; \
-                stream->items = realloc(stream->items, newSize); \
-                stream->cap = newSize; \
-                stream->end = stream->items + (size_t)newSize; \
-                stream->itemEnd = stream->items + ilen; \
-} while(0)
-
-// macro that always expands if not enough space to double the size
-#define FireStream_EXPAND_IF(stream, space) if(space > (stream->end - stream->itemEnd)) FireStream_EXPAND(stream, stream->cap + space * 2)
-
-// macro for moving the end marker in the stream back, primarily for reducing
-#define FireStream_SHORTEN(stream, endMark) do { \
-                if(endMark < FireStream_LEN(stream)) { \
-                        stream->itemEnd = stream->items + endMark; \
-                } \
-} while(0)
-
-// Sets the stream to a new range of numbers, expanding if needed and using pre-existing memory
-#define FireStream_SET_ZRNG(stream, endMark) do { \
-                FireStream_EXPAND_IF(stream, ((size_t)endMark * (sizeof(double) + 1))); \
-                stream->itemEnd = stream->items; \
-                for (double i = 0; i < endMark; i++) { \
-                        FireStream_PUT_LNUM(stream, i); \
-                } \
-} while(0)
-
-#define FireStream_SET_RNG(stream, startMark, endMark) do { \
-                FireStream_EXPAND_IF(stream, ((endMark-startMark) * (sizeof(double) + 1))); \
-                stream->itemEnd = stream->items; \
-                for (double i = startMark; i < endMark; i++) { \
-                        FireStream_PUT_LNUM(stream, i); \
-                } \
-} while(0)
-
-// unchecked method of simply adding a byte to the current itemEnd ptr.
-#define FireStream_PUT(stream, byte) *(unsigned char*)(stream->itemEnd++) = byte
-
-// writes one number to the end of the stream, expanding if needed
-#define FireStream_PUSH_NUM(stream, numPtr) do { \
-                FireStream_EXPAND_IF(stream, sizeof(double) + 1); \
-                FireStream_PUT(stream, FireStream_TYPE_NUM); \
-                *(double*)(stream->itemEnd) = *(double*)numPtr; \
-                stream->itemEnd += sizeof(double); \
-} while(0)
-
-// writes a literal double to the end of the stream
-#define FireStream_PUSH_LNUM(stream, num) do { \
-                FireStream_EXPAND_IF(stream, sizeof(double) + 1); \
-                FireStream_PUT(stream, FireStream_TYPE_NUM); \
-                *(double*)(stream->itemEnd) = num; \
-                stream->itemEnd += sizeof(double); \
-} while(0)
-
-// unchecked method of putting number with preceding byte marker onto stream
-#define FireStream_PUT_LNUM(stream, num) do { \
-                FireStream_PUT(stream, FireStream_TYPE_NUM); \
-                *(double*)(stream->itemEnd) = num; \
-                stream->itemEnd += sizeof(double); \
-} while(0)
-
-// pads the stream with n null bytes (0 bytes)
-// n is a literal integer
-#define FireStream_PAD_NULL(stream, n) do { \
-                FireStream_EXPAND_IF(stream, n); \
-                for (size_t i = 0; i < n; i++) *(unsigned char*)(stream->itemEnd++) = 0; \
-} while(0)
 
 
 
-
-
-
-// makes a copy of stream at ptr streamSrc to stream at ptr streamDst
-// streamDst must not have an already allocated items ptr.
-#define FireStream_COPY(streamDst, streamSrc) do { \
-                streamDst->cap = streamSrc->cap; \
-                streamDst->items = malloc(streamSrc->cap); \
-                memcpy(streamDst->items, streamSrc->items, streamSrc->cap); \
-                streamDst->end = streamDst->items + streamDst->cap; \
-                streamDst->itemEnd = streamDst->items + streamDst->len; \
-} while(0)
-
-// frees memory in a stream.
-#define FireStream_FREE(stream) do { \
-                free(stream->items); \
-                stream->items = NULL; \
-                stream->end = NULL; \
-                stream->itemEnd = NULL; \
-} while(0)
-
-// clears the entire buffer by 0 setting data, but does not destroy or deallocate
-#define FireStream_CLEAR(stream) do { \
-                unsigned char* dataPtr = stream->items; \
-                while(dataPtr != stream->itemEnd) *dataPtr++ = 0; \
-                stream->itemEnd = stream->items; \
-} while(0)
-
-
+//macro to check if realloc returns null, exits program if null pointer found
 #define FireStream_reall_check(ptr, newSize) if((ptr = realloc(ptr, newSize)) == NULL) { \
+                fprintf(stderr, "Memory error: Memory alloc for size %lu failed, out of memory.\n", newSize); \
+                exit(1); \
                 return 0; \
 }
 
@@ -236,17 +86,22 @@ FireStream_nullify(FireStream* stream)
         for(unsigned char* ptr = stream->items; ptr != stream->end; ptr++) *ptr = 0;
 }
 
-static inline int
-FireStream_expand_if(FireStream* stream, size_t size)
-{
-        if(FireStream_space(stream) < size) FireStream_expand(stream, size);
-}
-
 // expands the stream to a newsize, returns 0 if realloc failure
 int FireStream_expand(FireStream* stream, size_t newSize);
 
 //expands to twice the current size.
 int FireStream_expand_2x(FireStream* stream);
+
+static inline void
+FireStream_expand_if(FireStream* stream, size_t size)
+{
+        if(FireStream_space(stream) < size) FireStream_expand(stream, size);
+}
+
+static inline void
+FireStream_shorten(FireStream* stream, size_t size) {
+        if(size < FireStream_len(stream)) stream->itemEnd = stream->items + size;
+}
 
 // creates a stream from a pointer using default size.
 void FireStream_make(FireStream* stream);
@@ -254,6 +109,90 @@ void FireStream_make(FireStream* stream);
 //creates a stream with custom size.
 void FireStream_make_size(FireStream* stream, size_t size);
 
+//frees a stream and sets the buffer to zero and NULL
 void FireStream_free(FireStream* stream);
+
+//**** Write Methods *****
+
+//function to write any type, given some known size and address
+static inline void
+FireStream_write_any(FireStream* stream, void* val, size_t size)
+{
+        FireStream_expand_if(stream, size);
+        memcpy(stream->itemEnd, val, size);
+        stream->itemEnd += size;
+}
+
+static inline void
+FireStream_write_i8(FireStream* stream, int8_t num)
+{
+        FireStream_expand_if(stream, sizeof(int8_t));
+        *(int8_t*)(stream->itemEnd) = num;
+        stream->itemEnd += sizeof(int8_t);
+}
+
+static inline void
+FireStream_write_u8(FireStream* stream, uint8_t num)
+{
+        FireStream_expand_if(stream, sizeof(uint8_t));
+        *(uint8_t*)(stream->itemEnd) = num;
+        stream->itemEnd += sizeof(uint8_t);
+}
+
+static inline void
+FireStream_write_i16(FireStream* stream, int16_t num)
+{
+        FireStream_expand_if(stream, sizeof(int16_t));
+        *(int16_t*)(stream->itemEnd) = num;
+        stream->itemEnd += sizeof(int16_t);
+}
+
+static inline void
+FireStream_write_u16(FireStream* stream, uint16_t num)
+{
+        FireStream_expand_if(stream, sizeof(uint16_t));
+        *(uint16_t*)(stream->itemEnd) = num;
+        stream->itemEnd += sizeof(uint16_t);
+}
+
+static inline void
+FireStream_write_i32(FireStream* stream, int32_t num)
+{
+        FireStream_expand_if(stream, sizeof(int32_t));
+        *(int32_t*)(stream->itemEnd) = num;
+        stream->itemEnd += sizeof(int32_t);
+}
+
+static inline void
+FireStream_write_u32(FireStream* stream, uint32_t num)
+{
+        FireStream_expand_if(stream, sizeof(uint32_t));
+        *(uint32_t*)(stream->itemEnd) = num;
+        stream->itemEnd += sizeof(uint32_t);
+}
+
+static inline void
+FireStream_write_i64(FireStream* stream, int64_t num)
+{
+        FireStream_expand_if(stream, sizeof(int64_t));
+        *(int64_t*)(stream->itemEnd) = num;
+        stream->itemEnd += sizeof(int64_t);
+}
+
+static inline void
+FireStream_write_u64(FireStream* stream, uint64_t num)
+{
+        FireStream_expand_if(stream, sizeof(uint64_t));
+        *(uint64_t*)(stream->itemEnd) = num;
+        stream->itemEnd += sizeof(uint64_t);
+}
+
+static inline void
+FireStream_write_dbl(FireStream* stream, double num)
+{
+        FireStream_expand_if(stream, sizeof(double));
+        *(double*)(stream->itemEnd) = num;
+        stream->itemEnd += sizeof(double);
+}
 
 #endif

--- a/include/FireStream.h
+++ b/include/FireStream.h
@@ -183,8 +183,12 @@
 } while(0)
 
 
+#define FireStream_reall_check(ptr, newSize) if((ptr = realloc(ptr, newSize)) == NULL) { \
+                return 0; \
+}
 
 
+// struct to represent Fire's Stream
 
 struct FireStream
 {
@@ -197,7 +201,59 @@ struct FireStream
 typedef struct FireStream FireStream;
 
 
+// returns the length in bytes of the elements in the stream.
+static inline size_t
+FireStream_len(FireStream* stream)
+{
+        return stream->itemEnd - stream->items;
+}
+
+// returns the space remaining in the stream.
+static inline size_t
+FireStream_space(FireStream* stream)
+{
+        return stream->end - stream->itemEnd;
+}
+
+// Checks if the stream can fit some size of data.
+static inline int
+FireStream_fits(FireStream* stream, size_t size)
+{
+        return FireStream_space(stream) > size;
+}
+
+// Resets the write head of the stream to the beginning, allowing reusage of existing memory.
+// This saves reallocation of memory during mapping, filtering, etc.
+static inline void
+FireStream_reset(FireStream* stream)
+{
+        stream->itemEnd = stream->items;
+}
+
+static inline void
+FireStream_nullify(FireStream* stream)
+{
+        for(unsigned char* ptr = stream->items; ptr != stream->end; ptr++) *ptr = 0;
+}
+
+static inline int
+FireStream_expand_if(FireStream* stream, size_t size)
+{
+        if(FireStream_space(stream) < size) FireStream_expand(stream, size);
+}
+
+// expands the stream to a newsize, returns 0 if realloc failure
+int FireStream_expand(FireStream* stream, size_t newSize);
+
+//expands to twice the current size.
+int FireStream_expand_2x(FireStream* stream);
+
 // creates a stream from a pointer using default size.
-void FireStream_Make(FireStream* stream);
+void FireStream_make(FireStream* stream);
+
+//creates a stream with custom size.
+void FireStream_make_size(FireStream* stream, size_t size);
+
+void FireStream_free(FireStream* stream);
 
 #endif

--- a/include/FireStream.h
+++ b/include/FireStream.h
@@ -276,6 +276,22 @@ FireStream_read_n_at(FireStream* stream, void* buf, size_t size, size_t offset)
         memcpy(buf, stream->items + offset, size);
 }
 
+static inline int
+FireStream_is_empty(FireStream* stream)
+{
+        return stream->items == stream->itemEnd;
+}
+
+//returns percentage of capacity used, for optimization
+static inline double
+FireStream_cap_used(FireStream* stream)
+{
+        return (double)(stream->itemEnd - stream->items)/(double)(stream->cap);
+}
+
+//reads a certain number of elements from format to buf.
+int FireStream_read_fmt(FireStream* stream, void* buf, const char* fmt);
+
 
 
 

--- a/include/FireStream.h
+++ b/include/FireStream.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdarg.h>
 
 #include "FireTypes.h"
 #include "FireMap.h"
@@ -194,5 +195,88 @@ FireStream_write_dbl(FireStream* stream, double num)
         *(double*)(stream->itemEnd) = num;
         stream->itemEnd += sizeof(double);
 }
+
+// copies contents of stream to a void*
+static inline void
+FireStream_copy(FireStream* stream, void* dst)
+{
+        memcpy(dst, stream->items, FireStream_len(stream));
+}
+
+//writes or "packs" a series of variadic arguments into the binary stream
+int FireStream_write_fmt(FireStream* stream, const char* fmt, ...);
+
+// gets the ptr at some offset, bound checked.
+static inline void*
+FireStream_get_at_off(FireStream* stream, size_t offset)
+{
+        if(offset < FireStream_len(stream)) return stream->items + offset;
+        else return NULL;
+}
+
+static inline void
+FireStream_set_buf(FireStream* stream, void** buf)
+{
+        *buf = stream->items;
+}
+
+//reads one u8 from the stream
+static inline void
+FireStream_read_u8(FireStream* stream, uint8_t* ptr)
+{
+        *ptr = *(uint8_t*)(stream->items);
+}
+
+//reads one u8 from the stream at some offset
+static inline void
+FireStream_read_u8_at(FireStream* stream, uint8_t* ptr, size_t offset)
+{
+        *ptr = *(uint8_t*)(stream->items + offset);
+}
+
+//reads one i8 from the stream
+static inline void
+FireStream_read_i8(FireStream* stream, int8_t* ptr)
+{
+        *ptr = *(int8_t*)(stream->items);
+}
+
+//reads one i8 from the stream
+static inline void
+FireStream_read_i8_at(FireStream* stream, int8_t* ptr, size_t offset)
+{
+        *ptr = *(int8_t*)(stream->items + offset);
+}
+
+//reads one dbl from the stream
+static inline void
+FireStream_read_dbl(FireStream* stream, double* ptr)
+{
+        *ptr = *(double*)(stream->items);
+}
+
+//reads one dbl from the stream at an offset
+static inline void
+FireStream_read_dbl_at(FireStream* stream, double* ptr, size_t offset)
+{
+        *ptr = *(double*)(stream->items + offset);
+}
+
+//read a specified amount of bytes into a buffer
+static inline void
+FireStream_read_n(FireStream* stream, void* buf, size_t size)
+{
+        memcpy(buf, stream->items, size);
+}
+
+//read n bytes from stream into buf at some offset.
+static inline void
+FireStream_read_n_at(FireStream* stream, void* buf, size_t size, size_t offset)
+{
+        memcpy(buf, stream->items + offset, size);
+}
+
+
+
 
 #endif

--- a/include/FireStream.h
+++ b/include/FireStream.h
@@ -196,4 +196,8 @@ struct FireStream
 
 typedef struct FireStream FireStream;
 
+
+// creates a stream from a pointer using default size.
+void FireStream_Make(FireStream* stream);
+
 #endif

--- a/sandbox/Makefile
+++ b/sandbox/Makefile
@@ -1,0 +1,5 @@
+CC = gcc
+INC_DIR = ../include
+FLAGS :=  -Wall -I$(INC_DIR)
+
+sandbox: SandBox.c ; $(CC) $(FLAGS) SandBox.c -o $@

--- a/src/stream/FireStream.c
+++ b/src/stream/FireStream.c
@@ -45,3 +45,36 @@ void FireStream_free(FireStream* stream)
         stream->end = NULL;
         stream->cap = 0;
 }
+
+int FireStream_write_fmt(FireStream* stream, const char* fmt, ...)
+{
+        va_list pargs;
+        va_start(pargs, fmt);
+        while(*fmt)
+        {
+                switch(*fmt)
+                {
+                case 'b':
+                        FireStream_write_u8(stream, va_arg(pargs, int));
+                        break;
+                case 'i':
+                        FireStream_write_i32(stream, va_arg(pargs, int32_t));
+                        break;
+                case 'l':
+                        FireStream_write_i64(stream, va_arg(pargs, int64_t));
+                        break;
+                case 'd':
+                        FireStream_write_dbl(stream, va_arg(pargs, double));
+                        break;
+                case 'c':
+                        FireStream_write_i8(stream, va_arg(pargs, int));
+                        break;
+                default:
+                        va_end(pargs);
+                        return 0; //error
+                }
+                fmt++;
+        }
+        va_end(pargs);
+        return 1;
+}

--- a/src/stream/FireStream.c
+++ b/src/stream/FireStream.c
@@ -78,3 +78,26 @@ int FireStream_write_fmt(FireStream* stream, const char* fmt, ...)
         va_end(pargs);
         return 1;
 }
+
+int FireStream_read_fmt(FireStream* stream, void* buf, const char* fmt)
+{
+        void* reader = stream->items;
+        while(*fmt)
+        {
+                switch(*fmt)
+                {
+                case 'b':
+                        *(uint8_t*)buf = *(uint8_t*)reader;
+                        reader += sizeof(uint8_t);
+                        break;
+                case 'i':
+                case 'l':
+                case 'd':
+                case 'c':
+                default:
+                        return 0; //error in fmt
+                }
+                fmt++;
+        }
+        return 1;
+}

--- a/src/stream/FireStream.c
+++ b/src/stream/FireStream.c
@@ -1,3 +1,9 @@
 #include "FireStream.h"
 
-#define FOODOOD 5
+void FireStream_Make(FireStream* stream)
+{
+        stream->items = malloc(FireStream_DEFAULT_SIZE);
+        stream->cap = FireStream_DEFAULT_SIZE;
+        stream->end = stream->items + stream->cap;
+        stream->itemEnd = stream->items;
+}

--- a/src/stream/FireStream.c
+++ b/src/stream/FireStream.c
@@ -91,9 +91,21 @@ int FireStream_read_fmt(FireStream* stream, void* buf, const char* fmt)
                         reader += sizeof(uint8_t);
                         break;
                 case 'i':
+                        *(int32_t*)buf = *(int32_t*)reader;
+                        reader += sizeof(int32_t);
+                        break;
                 case 'l':
+                        *(int64_t*)buf = *(int64_t*)reader;
+                        reader += sizeof(int64_t);
+                        break;
                 case 'd':
+                        *(double*)buf = *(double*)reader;
+                        reader += sizeof(double);
+                        break;
                 case 'c':
+                        *(int8_t*)buf = *(int8_t*)reader;
+                        reader += sizeof(int8_t);
+                        break;
                 default:
                         return 0; //error in fmt
                 }

--- a/src/stream/FireStream.c
+++ b/src/stream/FireStream.c
@@ -1,9 +1,45 @@
 #include "FireStream.h"
 
-void FireStream_Make(FireStream* stream)
+
+int FireStream_expand(FireStream* stream, size_t newSize)
+{
+        size_t ilen = FireStream_len(stream);
+        if(stream->items = realloc(stream->items, newSize)) return 0;
+        stream->cap = newSize;
+        stream->end = stream->items + newSize;
+        stream->itemEnd = stream->items + ilen;
+}
+
+int FireStream_expand_2x(FireStream* stream)
+{
+        size_t ilen = FireStream_len(stream);
+        if(stream->items = realloc(stream->items, (stream->cap * 2))) return 0;
+        stream->cap *= 2;
+        stream->end = stream->items + stream->cap;
+        stream->itemEnd = stream->items + ilen;
+}
+
+void FireStream_make(FireStream* stream)
 {
         stream->items = malloc(FireStream_DEFAULT_SIZE);
         stream->cap = FireStream_DEFAULT_SIZE;
         stream->end = stream->items + stream->cap;
         stream->itemEnd = stream->items;
+}
+
+void FireStream_make_size(FireStream* stream, size_t size)
+{
+        stream->items = malloc(size);
+        stream->cap = size;
+        stream->end = stream->items + stream->cap;
+        stream->itemEnd = stream->items;
+}
+
+void FireStream_free(FireStream* stream)
+{
+        free(stream->items);
+        stream->items = NULL;
+        stream->itemEnd = NULL;
+        stream->end = NULL;
+        stream->cap = 0;
 }

--- a/src/stream/FireStream.c
+++ b/src/stream/FireStream.c
@@ -4,19 +4,21 @@
 int FireStream_expand(FireStream* stream, size_t newSize)
 {
         size_t ilen = FireStream_len(stream);
-        if(stream->items = realloc(stream->items, newSize)) return 0;
+        FireStream_reall_check(stream->items, newSize);
         stream->cap = newSize;
         stream->end = stream->items + newSize;
         stream->itemEnd = stream->items + ilen;
+        return 1;
 }
 
 int FireStream_expand_2x(FireStream* stream)
 {
         size_t ilen = FireStream_len(stream);
-        if(stream->items = realloc(stream->items, (stream->cap * 2))) return 0;
+        FireStream_reall_check(stream->items, (stream->cap * 2));
         stream->cap *= 2;
         stream->end = stream->items + stream->cap;
         stream->itemEnd = stream->items + ilen;
+        return 1;
 }
 
 void FireStream_make(FireStream* stream)


### PR DESCRIPTION
### Description

This addition implements an array of low-level read write methods for the Fire Stream struct type.

### Write:

* Write from specific sized int
* Write from void* (memcpy)
* Write from a double
* Write from variadic arg format string.

### Read:

* Read as type
* Read into buffer
* Read into buffer via format string

#### Misc

* space ratio remaining
* realloc safety macro